### PR TITLE
Fix update.sh and config.yaml in togovar-clinvar and togovar-dbsnp

### DIFF
--- a/link/togovar-clinvar/config.yaml
+++ b/link/togovar-clinvar/config.yaml
@@ -7,7 +7,7 @@ target:
   namespace: clinvar.vcv
   type: Variant
   label: ClinVar variant
-  prefix: http://purl.jp/bio/10/clinvar/accession/
+  prefix: http://ncbi.nlm.nih.gov/clinvar/variation/
 link:
   file: pair.tsv
   forward:
@@ -17,6 +17,5 @@ link:
     predicate: seeAlso
 update:
   frequency: Monthly
-  # NBDC will update the conversion table (tgvid2dbSNP.tsv)  
-  method: wget -c https://togovar.biosciencedbc.jp/public/togoid/tgvid2clinvar.tsv && mv tgvid2clinvar.tsv pair.tsv
+  method: update.sh > pair.tsv
 

--- a/link/togovar-clinvar/update.sh
+++ b/link/togovar-clinvar/update.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SPARQL query
+QUERY="
+PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+PREFIX dct: <http://purl.org/dc/terms/>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX cvo:  <http://purl.jp/bio/10/clinvar/>
+
+SELECT ?tgv_id ?vcv
+WHERE {
+  GRAPH <http://togovar.biosciencedbc.jp/variation>{
+     ?variation dct:identifier ?tgv_id.
+  }
+  
+  GRAPH <http://togovar.biosciencedbc.jp/variation/annotation/clinvar>{
+     ?variation tgvo:condition ?condition .
+     ?condition rdfs:seeAlso ?clinvar .
+  }
+  
+  BIND(REPLACE(STR(?clinvar), 'http://ncbi.nlm.nih.gov/clinvar/variation/', '') AS ?vcv) 
+}"
+# curl -> format -> delete header
+curl -s -H "Accept: text/csv" --data-urlencode "query=$QUERY" https://togovar-dev.biosciencedbc.jp/sparql | sed -e 's/\"//g;  s/,/\t/g' | sed -e '1d'

--- a/link/togovar-dbsnp/config.yaml
+++ b/link/togovar-dbsnp/config.yaml
@@ -17,6 +17,5 @@ link:
     predicate: seeAlso
 update:
   frequency: Monthly
-  # NBDC will update the conversion table (tgvid2dbSNP.tsv)  
-  method: wget -c https://togovar.biosciencedbc.jp/public/togoid/tgvid2dbSNP.tsv && mv tgvid2dbSNP.tsv pair.tsv
+  method: update.sh 
 

--- a/link/togovar-dbsnp/update.sh
+++ b/link/togovar-dbsnp/update.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# SPARQL query
+QUERY="
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX tgvo: <http://biohackathon.org/resource/faldo#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tgvo: <http://togovar.biosciencedbc.jp/vocabulary/>
+PREFIX idt: <http://identifiers.org/>
+
+SELECT distinct ?tgv_id ?rs
+WHERE
+{
+  GRAPH <http://togovar.biosciencedbc.jp/variation>{
+    ?variation dct:identifier ?tgv_id.
+    ?variation rdfs:seeAlso ?dbsnp .
+  }
+  BIND(REPLACE(STR(?dbsnp), 'http://identifiers.org/dbsnp/', '') AS ?rs)
+}"
+# curl -> format -> delete header
+curl -s -H "Accept: text/csv" --data-urlencode "query=$QUERY" https://togovar-dev.biosciencedbc.jp/sparql | sed -e 's/\"//g;  s/,/\t/g' | sed -e '1d' 


### PR DESCRIPTION
- https://sparqlthon.slack.com/archives/C0160NRTZAN/p1613466727097900 に対して以下は対応しました。
  - togovar-clinvar
  - toogovar-dbsnp
- togovar-dbsnpのupdate.shの出力が100万件ちょうどなのでvirtuosoか何かのlimitにかかっている可能性があります。
- 残りの以下は明日の朝までに対応するように努めます。
  - togovar-ensembl.transcript
  - togovar-ensembl
  - togovar-hgnc
  - togovar-medgen
  - togovar-ncbigene
  - togovar-pubmed
  - togovar-refseq.mRNA