### PR TITLE
fix check state return statement

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -247,8 +247,11 @@ module TogoID
             end
           end
         end
-        return check
+      else
+        $stderr.puts "# Error: Failed to create #{tsv} or created file is empty" if $verbose
+        check = false
       end
+      return check
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -247,11 +247,11 @@ module TogoID
             end
           end
         end
+        return check
       end
-      return check
     end
   end
-  
+
   # Methods for preparation
   module Prepare
     # Entry point for preparation


### PR DESCRIPTION
`validate_tsv_output` メソッドの `if File.exists?(tsv) and File.size(tsv) > 0` の判定が false だった場合にブロックを通過してデフォルト値の `check=true` が返ってしまう。結果として、tsvファイルが空なのに `Success!!` とか言われる。エラーメッセージと `check` の値を修正。