### PR TITLE
output multiple relations

### DIFF
--- a/bin/togoid-config
+++ b/bin/togoid-config
@@ -27,14 +27,14 @@ else
   exit 1
 end
 
-config = TogoID::Config.new(yaml)
+configs = TogoID::Configs.new(yaml)
 
 case mode
 when "convert"
-  config.exec_convert
+  configs.exec_convert
 when "update"
-  config.exec_update
+  configs.exec_update
 else
-  config.exec_check
+  configs.exec_check
 end
 


### PR DESCRIPTION
config.yaml に複数関係が記述されている場合に、`togoid-config` コマンドが適切に出力できるよう対応した。
これまでは、一つめに記述された関係のみ出力し、複数ある場合は手動で更新していた。
## tsv 出力
`togoid-config` コマンドの `update` は、各関係ごとに tsv を出力するように修正された。複数関係がある場合、各 tsv は `{source}-{target}-{TIO}.tsv` というファイル名。
この際、一つめに記述された関係の tsv は、`{source}-{target}.tsv` として copy されるようにした。これは、今回は Rakefile には変更を加えておらず、Rakefile はこの名前のファイルが出力されることを期待しているため。現状の Rakefile は、「出力される tsv や ttl ファイルのファイル名から拡張子を除いた部分」と「config のディレクトリ名」が同一であるという強い前提のもとに実装されており、これを変えるのはかなり難しかった。そのため妥協で今回の仕様にした。
結果として、
```
rake output/tsv/chembl_target-uniprot.tsv
```
を実行すると
`chembl_target-uniprot-TIO_000002.tsv`
`chembl_target-uniprot-TIO_000130.tsv`
`chembl_target-uniprot-TIO_000132.tsv`
`chembl_target-uniprot.tsv`
が出力され、`chembl_target-uniprot.tsv` は `chembl_target-uniprot-TIO_000002.tsv` と同じ、となる。
本当にほしいのは TIO 付きの tsv ファイル群であるのだが、Rakefile 視点ではこれらのファイルは副産物のようになってしまっている。やや違和感のある実装だが、妥協。実際、取得元のデータベースが同じである以上、各 tsv の更新のタイミングは同じであることがほとんどであるはずなので、不都合はないと思われる。
## ttl 出力
`togoid-config` コマンドの `convert` は、config.yaml ごとに一つの ttl ファイルに全ての関係を出力するように変更された。
